### PR TITLE
Add optional alphabetical sorting for OATH and WebAuthn credentials

### DIFF
--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -230,6 +230,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "The output comes with Enter",
     ),
     "passStatus": MessageLookupByLibrary.simpleMessage("Status"),
+    "passkey": MessageLookupByLibrary.simpleMessage("Passkey"),
     "pinChanged": MessageLookupByLibrary.simpleMessage(
       "PIN has been successfully changed.",
     ),

--- a/lib/generated/intl/messages_zh_Hans.dart
+++ b/lib/generated/intl/messages_zh_Hans.dart
@@ -185,6 +185,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "passSlotStatic": MessageLookupByLibrary.simpleMessage("静态口令"),
     "passSlotWithEnter": MessageLookupByLibrary.simpleMessage("附加回车"),
     "passStatus": MessageLookupByLibrary.simpleMessage("状态"),
+    "passkey": MessageLookupByLibrary.simpleMessage("通行密钥"),
     "pinChanged": MessageLookupByLibrary.simpleMessage("PIN 修改成功"),
     "pinIncorrect": MessageLookupByLibrary.simpleMessage("PIN 输入错误"),
     "pinInvalidLength": MessageLookupByLibrary.simpleMessage("长度错误"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1775,6 +1775,11 @@ class S {
     );
   }
 
+  /// `Passkey`
+  String get passkey {
+    return Intl.message('Passkey', name: 'passkey', desc: '', args: []);
+  }
+
   /// `View User ID`
   String get viewUserId {
     return Intl.message('View User ID', name: 'viewUserId', desc: '', args: []);

--- a/lib/helper/storage/local_storage.dart
+++ b/lib/helper/storage/local_storage.dart
@@ -7,6 +7,8 @@ final log = Logging.logger('Console:helper:storage');
 class LocalStorage {
   static const String _languageKey = 'lang_code';
   static const String _startPageKey = 'start_page';
+  static const String _oathSortKey = 'oath_sort_alphabetically';
+  static const String _webauthnSortKey = 'webauthn_sort_alphabetically';
 
   static SharedPreferences? _preferencesInstance;
 
@@ -52,5 +54,21 @@ class LocalStorage {
     final keys = preferences.getKeys().where((key) => key.startsWith('pin:'));
     log.i('Clearing pin cache: $keys');
     await Future.wait(keys.map((key) => preferences.remove(key)));
+  }
+
+  static Future<bool> setOathSortAlphabetically(bool value) {
+    return preferences.setBool(_oathSortKey, value);
+  }
+
+  static bool getOathSortAlphabetically() {
+    return preferences.getBool(_oathSortKey) ?? false;
+  }
+
+  static Future<bool> setWebAuthnSortAlphabetically(bool value) {
+    return preferences.setBool(_webauthnSortKey, value);
+  }
+
+  static bool getWebAuthnSortAlphabetically() {
+    return preferences.getBool(_webauthnSortKey) ?? false;
   }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -204,6 +204,7 @@
   "pivVerifyManagementKey": "Verify Management Key",
   "validationHexString": "Please input a valid hexadecimal string.",
   "validationExactLength": "Need exact {length} characters",
+  "passkey": "Passkey",
   "viewUserId": "View User ID",
   "savePinOnDevice": "Save the PIN on this device",
   "settingsClearPinCache": "Clear Saved PINs",

--- a/lib/l10n/intl_zh_Hans.arb
+++ b/lib/l10n/intl_zh_Hans.arb
@@ -280,6 +280,7 @@
       }
     }
   },
+  "passkey": "通行密钥",
   "viewUserId": "查看用户 ID",
   "savePinOnDevice": "在此设备上保存 PIN",
   "settingsClearPinCache": "清除已保存的 PIN",

--- a/lib/views/applets/webauthn/webauthn_page.dart
+++ b/lib/views/applets/webauthn/webauthn_page.dart
@@ -1,5 +1,6 @@
 import 'package:canokey_console/controller/applets/webauthn/webauthn_controller.dart';
 import 'package:canokey_console/generated/l10n.dart';
+import 'package:canokey_console/helper/storage/local_storage.dart';
 import 'package:canokey_console/helper/utils/ui_mixins.dart';
 import 'package:canokey_console/helper/widgets/customized_text.dart';
 import 'package:canokey_console/helper/widgets/no_credential_screen.dart';
@@ -7,11 +8,13 @@ import 'package:canokey_console/helper/widgets/poll_canokey_screen.dart';
 import 'package:canokey_console/helper/widgets/responsive.dart';
 import 'package:canokey_console/helper/widgets/search_box.dart';
 import 'package:canokey_console/helper/widgets/spacing.dart';
+import 'package:canokey_console/models/webauthn.dart';
 import 'package:canokey_console/views/applets/webauthn/widgets/top_actions.dart';
 import 'package:canokey_console/views/applets/webauthn/widgets/webauthn_item_card.dart';
 import 'package:canokey_console/views/layout/layout.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:lucide_icons/lucide_icons.dart';
 
 class WebAuthnPage extends StatefulWidget {
   const WebAuthnPage({super.key});
@@ -23,19 +26,52 @@ class WebAuthnPage extends StatefulWidget {
 class _WebAuthnPageState extends State<WebAuthnPage> with SingleTickerProviderStateMixin, UIMixin {
   final WebAuthnController controller = Get.put(WebAuthnController());
   final RxString searchText = ''.obs;
+  final RxBool sortAlphabetically = false.obs;
   final GlobalKey<FormState> _searchFormKey = GlobalKey<FormState>();
+
+  late final Worker _sortWorker;
 
   @override
   void initState() {
     super.initState();
     Get.put(searchText, tag: 'webauthn_search');
+    Get.put(sortAlphabetically, tag: 'webauthn_sort');
+    
+    // Load saved preference
+    sortAlphabetically.value = LocalStorage.getWebAuthnSortAlphabetically();
+    
+    // Save preference when it changes
+    _sortWorker = ever(sortAlphabetically, (bool value) {
+      LocalStorage.setWebAuthnSortAlphabetically(value);
+    });
+  }
+
+  @override
+  void dispose() {
+    _sortWorker.dispose();
+    Get.delete<RxString>(tag: 'webauthn_search');
+    Get.delete<RxBool>(tag: 'webauthn_sort');
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return Layout(
       title: 'WebAuthn',
-      topActions: TopActions(controller: controller),
+      topActions: Row(
+        children: [
+          Obx(() => InkWell(
+            onTap: () => sortAlphabetically.value = !sortAlphabetically.value,
+            child: Icon(
+              sortAlphabetically.value ? LucideIcons.arrowDownAZ : LucideIcons.clock,
+              size: 20,
+              color: topBarTheme.onBackground,
+            ),
+          )),
+          Spacing.width(12),
+          TopActions(controller: controller),
+        ],
+      ),
       child: GetBuilder(
         init: controller,
         builder: (_) {
@@ -67,11 +103,39 @@ class _WebAuthnPageState extends State<WebAuthnPage> with SingleTickerProviderSt
                                   item.userDisplayName.toLowerCase().contains(searchText.value.toLowerCase()))
                               .toList();
                       if (filteredItems.isEmpty) return Center(child: CustomizedText.bodyMedium(S.of(context).noMatchingCredential, fontSize: 24));
+                      final items = List<WebAuthnItem>.from(filteredItems);
+                      if (sortAlphabetically.value) {
+                        items.sort((a, b) {
+                          final aRpId = a.rpId.split('.').reversed.toList();
+                          final bRpId = b.rpId.split('.').reversed.toList();
+                          if (aRpId.length >= 2) {
+                            final temp = aRpId[0];
+                            aRpId[0] = aRpId[1];
+                            aRpId[1] = temp;
+                          }
+                          if (bRpId.length >= 2) {
+                            final temp = bRpId[0];
+                            bRpId[0] = bRpId[1];
+                            bRpId[1] = temp;
+                          }
+                          for (int i = 0; i < aRpId.length && i < bRpId.length; i++) {
+                            final aRpIdChip = aRpId[i];
+                            final bRpIdChip = bRpId[i];
+                            if (aRpIdChip != bRpIdChip) {
+                              return aRpIdChip.toLowerCase().compareTo(bRpIdChip.toLowerCase());
+                            }
+                          }
+                          if (aRpId.length != bRpId.length) {
+                            return aRpId.length.compareTo(bRpId.length);
+                          }
+                          return a.userName.toLowerCase().compareTo(b.userName.toLowerCase());
+                        });
+                      }
                       return GridView.builder(
                         physics: ScrollPhysics(),
                         shrinkWrap: true,
                         scrollDirection: Axis.vertical,
-                        itemCount: filteredItems.length,
+                        itemCount: items.length,
                         gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
                           maxCrossAxisExtent: 500,
                           crossAxisSpacing: 16,
@@ -79,7 +143,7 @@ class _WebAuthnPageState extends State<WebAuthnPage> with SingleTickerProviderSt
                           mainAxisExtent: 120,
                         ),
                         itemBuilder: (context, index) => WebAuthnItemCard(
-                          item: filteredItems[index],
+                          item: items[index],
                           controller: controller,
                         ),
                       );

--- a/lib/views/applets/webauthn/widgets/webauthn_item_card.dart
+++ b/lib/views/applets/webauthn/widgets/webauthn_item_card.dart
@@ -33,7 +33,7 @@ class WebAuthnItemCard extends StatelessWidget with UIMixin {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Flexible(child: CustomizedText.bodyMedium(item.userDisplayName, fontSize: 16, fontWeight: 600, overflow: TextOverflow.ellipsis)),
+              Flexible(child: CustomizedText.bodyMedium(item.userDisplayName.isEmpty ? S.of(context).passkey : item.userDisplayName, fontSize: 16, fontWeight: 600, overflow: TextOverflow.ellipsis)),
               CustomizedContainer.none(
                 paddingAll: 8,
                 borderRadiusAll: 5,


### PR DESCRIPTION
This pull request adds the ability to sort OATH and WebAuthn credential lists alphabetically, persists the user's sorting preference, and improves the display of passkey credentials. The most significant changes are the addition of sorting toggles and preference storage for both OATH and WebAuthn pages, as well as a minor localization improvement.

**Sorting and Preference Persistence:**

* Added new boolean keys (`_oathSortKey`, `_webauthnSortKey`) and corresponding getter/setter methods in `LocalStorage` to save and retrieve sorting preferences for OATH and WebAuthn credentials. [[1]](diffhunk://#diff-6dbeefe1e87c8f5f71c44f030e5619f9ba5534e1e53af3ed58c5108dff2fdea7R10-R11) [[2]](diffhunk://#diff-6dbeefe1e87c8f5f71c44f030e5619f9ba5534e1e53af3ed58c5108dff2fdea7R58-R73)
* On both `OathPage` and `WebAuthnPage`, added a toggle button (with icon) to switch between default and alphabetical sorting, and wired this to persist the preference using `LocalStorage`. The sorting state is now managed reactively and cleaned up properly on widget disposal. [[1]](diffhunk://#diff-4d47e17cc61f1e292d5bf017ce7b8b6ad3f32bd36b6b163f665cfa0b6e89e45dR4) [[2]](diffhunk://#diff-4d47e17cc61f1e292d5bf017ce7b8b6ad3f32bd36b6b163f665cfa0b6e89e45dR24) [[3]](diffhunk://#diff-4d47e17cc61f1e292d5bf017ce7b8b6ad3f32bd36b6b163f665cfa0b6e89e45dR38-R57) [[4]](diffhunk://#diff-4d47e17cc61f1e292d5bf017ce7b8b6ad3f32bd36b6b163f665cfa0b6e89e45dR80-R82) [[5]](diffhunk://#diff-4d47e17cc61f1e292d5bf017ce7b8b6ad3f32bd36b6b163f665cfa0b6e89e45dL75-R110) [[6]](diffhunk://#diff-4d47e17cc61f1e292d5bf017ce7b8b6ad3f32bd36b6b163f665cfa0b6e89e45dR139-R155) [[7]](diffhunk://#diff-09aed3141d0a3df77fdef75c0c5b974b89a555b8b4888477a026fc2c15a93ddfR3-R17) [[8]](diffhunk://#diff-09aed3141d0a3df77fdef75c0c5b974b89a555b8b4888477a026fc2c15a93ddfR29-R74)

**Sorting Logic:**

* Implemented alphabetical sorting for OATH credentials by name and for WebAuthn credentials by `rpId` domain compared by SLD, TLD and then subdomains, with a fallback to username. [[1]](diffhunk://#diff-4d47e17cc61f1e292d5bf017ce7b8b6ad3f32bd36b6b163f665cfa0b6e89e45dR139-R155) [[2]](diffhunk://#diff-09aed3141d0a3df77fdef75c0c5b974b89a555b8b4888477a026fc2c15a93ddfR106-R146)

**Localization and UI Improvements:**

* Added a localized label for "Passkey" in both English and Simplified Chinese, and updated the WebAuthn item card to use this label when `userDisplayName` is empty. [[1]](diffhunk://#diff-d38a1072799c0e0b8936fb54ea8bcc732c76241afed954d025815eb8369aad32R207) [[2]](diffhunk://#diff-09f88601b9ff9d31024739210c403cecd45a952f4afbb74b45b537f04e4acc8aR283) [[3]](diffhunk://#diff-f75948a32f7b7399e3e6fa3081e8798d6e0a031fd3d199387d5ec29f2a20a317L36-R36)

---

Resolves #13